### PR TITLE
Add Linux AArch64 wheel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,37 @@ jobs:
 
       install:
         - pip install --upgrade pip setuptools
-        - pip install cython cibuildwheel==1.0.0
+        - pip install cython cibuildwheel==1.12.0
+
+      script:
+        - cibuildwheel --output-dir wheelhouse
+
+      env:
+        - CIBW_BEFORE_BUILD='pip install cython'
+      deploy:
+        name: Linux
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: wheelhouse/*
+        skip_cleanup: true
+        draft: true
+        prerelease: true
+        overwrite: true
+        on:
+          tags: true
+
+    - stage: wheels
+      name: Wheels for Linux AArch64
+      os: linux
+      arch: arm64
+      language: python
+      python:
+        - "3.6"
+
+      install:
+        - pip install --upgrade pip setuptools
+        - pip install cython cibuildwheel==1.12.0
 
       script:
         - cibuildwheel --output-dir wheelhouse
@@ -49,12 +79,13 @@ jobs:
 
       install:
         - pip install --upgrade pip setuptools
-        - pip install cython cibuildwheel==1.0.0
+        - pip install cython cibuildwheel==1.1.0
 
       script:
         - cibuildwheel --output-dir wheelhouse
 
       env:
+        - CIBW_SKIP='cp27-* cp35-*'
         - CIBW_BEFORE_BUILD='pip install cython'
       deploy:
         name: Mac OS X
@@ -70,163 +101,21 @@ jobs:
           tags: true
 
     - stage: wheels
-      name: Wheels for Windows Python 2.7
-      os: windows
-      language: shell
-
-      install:
-        - choco install python2 --version 2.7.16 --sidebyside -y --forcex86 --force --params "/InstallDir:C:\Python27"
-        - choco install --ignore-dependencies vcpython27
-        # extra include for stdint.h
-        - export INCLUDE="C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\include"
-
-      script:
-        - C:/Python27/python -m pip install cibuildwheel==1.0.0
-        - C:/Python27/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-      env:
-        - CIBW_BUILD='cp27-win32'
-        - CIBW_BEFORE_BUILD='python -m pip install cython'
-      deploy:
-        name: Windows Python 2.7
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: wheelhouse/*
-        skip_cleanup: true
-        draft: true
-        prerelease: true
-        overwrite: true
-        on:
-          tags: true
-
-    - stage: wheels
-      name: Wheels for Windows Python 2.7 x64
-      os: windows
-      language: shell
-
-      install:
-        - choco install python2 --version 2.7.16 --sidebyside -y --force --params "/InstallDir:C:\Python27-x64"
-        - choco install --ignore-dependencies vcpython27
-
-        - export PATH="C:\\Program Files (x86)\\common files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin\\amd64;$PATH"
-        - export INCLUDE="C:\\Program Files (x86)\\common files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\Include;C:\\Program Files (x86)\\common files\\Microsoft\\Visual C++ for Python\\9.0\\WinSDK\\Include;C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\include"
-        - export LIB="C:\\Program Files (x86)\\common files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\Lib\\amd64;C:\\Program Files (x86)\\common files\\Microsoft\\Visual C++ for Python\\9.0\\WinSDK\\Lib\\x64"
-
-      script:
-        - C:/Python27-x64/python -m pip install cibuildwheel==1.0.0
-        - C:/Python27-x64/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-      env:
-        - CIBW_BUILD='cp27-win_amd64'
-        - CIBW_BEFORE_BUILD='python -m pip install cython'
-      deploy:
-        name: Windows Python 2.7 x64
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: wheelhouse/*
-        skip_cleanup: true
-        draft: true
-        prerelease: true
-        overwrite: true
-        on:
-          tags: true
-
-    - stage: wheels
-      name: Wheels for Windows Python 3.5
-      os: windows
-      language: shell
-
-      install:
-        - choco install python3 --version 3.5.2.20161029 -y --forcex86 --force --params "/InstallDir:C:\Python35"
-
-      script:
-        - C:/Python35/python -m pip install cibuildwheel==1.0.0
-        - C:/Python35/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-      env:
-        - CIBW_BUILD='cp35-win32'
-        - CIBW_BEFORE_BUILD='python -m pip install cython'
-      deploy:
-        name: Windows Python 3.5
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: wheelhouse/*
-        skip_cleanup: true
-        draft: true
-        prerelease: true
-        overwrite: true
-        on:
-          tags: true
-
-    - stage: wheels
-      name: Wheels for Windows Python 3.5 x64
-      os: windows
-      language: shell
-
-      install:
-        - choco install python3 --version 3.5.2.20161029 -y --force --params "/InstallDir:C:\Python35-x64"
-
-      script:
-        - C:/Python35-x64/python -m pip install cibuildwheel==1.0.0
-        - C:/Python35-x64/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-      env:
-        - CIBW_BUILD='cp35-win_amd64'
-        - CIBW_BEFORE_BUILD='python -m pip install cython'
-      deploy:
-        name: Windows Python 3.5 x64
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: wheelhouse/*
-        skip_cleanup: true
-        draft: true
-        prerelease: true
-        overwrite: true
-        on:
-          tags: true
-
-    - stage: wheels
-      name: Wheels for Windows Python 3.[678]
+      name: Wheels for Windows Python 3.[56789]
       os: windows
       language: shell
 
       install:
         - choco install python3 --version 3.6.8 --sidebyside -y --forcex86 --force --params "/InstallDir:C:\Python36"
-        - choco install python3 --version 3.6.8 --sidebyside -y --force --params "/InstallDir:C:\Python36-x64"
-
-        - choco install python3 --version 3.7.4 --sidebyside -y --forcex86 --force --params "/InstallDir:C:\Python37"
-        - choco install python3 --version 3.7.4 --sidebyside -y --force --params "/InstallDir:C:\Python37-x64"
-
-        - choco install python3 --version 3.8.0 --sidebyside -y --forcex86 --force --params "/InstallDir:C:\Python38"
-        - choco install python3 --version 3.8.0 --sidebyside -y --force --params "/InstallDir:C:\Python38-x64"
       script:
-        - C:/Python36/python -m pip install cibuildwheel==1.0.0
-        - C:/Python36-x64/python -m pip install cibuildwheel==1.0.0
-
-        - C:/Python37/python -m pip install cibuildwheel==1.0.0
-        - C:/Python37-x64/python -m pip install cibuildwheel==1.0.0
-
-        - C:/Python38/python -m pip install cibuildwheel==1.0.0
-        - C:/Python38-x64/python -m pip install cibuildwheel==1.0.0
-
+        - C:/Python36/python -m pip install cibuildwheel==1.12.0
         - C:/Python36/python -m cibuildwheel --platform windows --output-dir wheelhouse
-        - C:/Python36-x64/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-        - C:/Python37/python -m cibuildwheel --platform windows --output-dir wheelhouse
-        - C:/Python37-x64/python -m cibuildwheel --platform windows --output-dir wheelhouse
-
-        - C:/Python38/python -m cibuildwheel --platform windows --output-dir wheelhouse
-        - C:/Python38-x64/python -m cibuildwheel --platform windows --output-dir wheelhouse
 
       env:
-        - CIBW_BUILD='cp3[678]-*'
+        - CIBW_BUILD='cp3[56789]-*'
         - CIBW_BEFORE_BUILD='python -m pip install cython'
       deploy:
-        name: Windows Python 3.[678]
+        name: Windows Python 3.[56789]
         provider: releases
         api_key: $GITHUB_TOKEN
         file_glob: true


### PR DESCRIPTION
Fix:
1) Removed python 2.7 wheel build support which was failing and outdated as well.
2) Removed python 3.5 wheel build support for Mac OS which was failing and outdated as well.
3) Add AArch64 wheel build support
